### PR TITLE
adding nextflow dsl1 message in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ rm /path/to/process/workdir/db/LOCK
 **NOTE**
 
 > The following pipeline parameters are used for Nextflow: PIPELINE_PATH, DATA_PATH, RESULTS_PATH, WORKDIR. The rest of the parameters are used for each of the image processing steps in the pipeline.
+
+This pipeline is currently using Nextflow DSL1. Currently, this version is not supported by Nextflow and we will be migrating the nextflow script to DSL2 in a future release. Please, follow this [issue](https://github.com/AllenNeuralDynamics/aind-smartspim-pipeline/issues/7) for more information.
 ---
 
 # Datasets for pipeline processing


### PR DESCRIPTION
Currently, nextflow does not support the version DSL1. Please, check issue #7. We will have to migrate our slurm nextflow script to DSL2 but keep the Code Ocean version in DSL1 until the update it to DSL2? We have to talk this through since I'd like to keep both in the same version [Guide to move to DSL2](https://www.nextflow.io/docs/latest/dsl1.html). For now, I'm just including a message in the README.